### PR TITLE
Fix React warning

### DIFF
--- a/src/components/AddressesScreenHeaderRight.tsx
+++ b/src/components/AddressesScreenHeaderRight.tsx
@@ -1,0 +1,40 @@
+/*
+Copyright 2018 - 2022 The Alephium Authors
+This file is part of the alephium project.
+
+The library is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+The library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with the library. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import { NavigationProp, useNavigation } from '@react-navigation/native'
+import { Plus as PlusIcon } from 'lucide-react-native'
+import React from 'react'
+import { useTheme } from 'styled-components/native'
+
+import RootStackParamList from '../navigation/rootStackRoutes'
+import Button from './buttons/Button'
+
+const AddressesScreenHeaderRight = () => {
+  const theme = useTheme()
+  const navigation = useNavigation<NavigationProp<RootStackParamList>>()
+
+  return (
+    <Button
+      onPress={() => navigation.navigate('NewAddressScreen')}
+      icon={<PlusIcon size={24} color={theme.global.accent} />}
+      type="transparent"
+    />
+  )
+}
+
+export default AddressesScreenHeaderRight

--- a/src/screens/AddressesScreen.tsx
+++ b/src/screens/AddressesScreen.tsx
@@ -16,15 +16,15 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { NavigationProp, useFocusEffect, useNavigation } from '@react-navigation/native'
+import { useFocusEffect } from '@react-navigation/native'
 import { StackScreenProps } from '@react-navigation/stack'
 import { ArrowDown, ArrowUp, Settings2 } from 'lucide-react-native'
-import { Plus as PlusIcon } from 'lucide-react-native'
-import { useCallback, useLayoutEffect, useState } from 'react'
-import { LayoutChangeEvent, Pressable, StyleProp, View, ViewStyle } from 'react-native'
+import { useCallback, useState } from 'react'
+import { LayoutChangeEvent, StyleProp, View, ViewStyle } from 'react-native'
 import styled, { useTheme } from 'styled-components/native'
 
 import AddressCard from '../components/AddressCard'
+import AddressesScreenHeaderRight from '../components/AddressesScreenHeaderRight'
 import AddressesTokensList from '../components/AddressesTokensList'
 import Button from '../components/buttons/Button'
 import ButtonsRow from '../components/buttons/ButtonsRow'
@@ -45,24 +45,9 @@ interface ScreenProps extends StackScreenProps<InWalletTabsParamList & RootStack
   style?: StyleProp<ViewStyle>
 }
 
-const AddressesScreenHeader = (props: Partial<DefaultHeaderProps>) => {
-  const theme = useTheme()
-  const navigation = useNavigation<NavigationProp<RootStackParamList>>()
-
-  return (
-    <DefaultHeader
-      HeaderLeft="Addresses"
-      HeaderRight={
-        <Button
-          onPress={() => navigation.navigate('NewAddressScreen')}
-          icon={<PlusIcon size={24} color={theme.global.accent} />}
-          type="transparent"
-        />
-      }
-      {...props}
-    />
-  )
-}
+const AddressesScreenHeader = (props: Partial<DefaultHeaderProps>) => (
+  <DefaultHeader HeaderLeft="Addresses" HeaderRight={<AddressesScreenHeaderRight />} {...props} />
+)
 
 const AddressesScreen = ({ navigation }: ScreenProps) => {
   const addressHashes = useAppSelector(selectAddressIds) as AddressHash[]
@@ -80,16 +65,6 @@ const AddressesScreen = ({ navigation }: ScreenProps) => {
     setCurrentAddressHash(addressHashes[index])
     setAreButtonsDisabled(false)
   }
-
-  useLayoutEffect(() => {
-    navigation.setOptions({
-      headerRight: () => (
-        <Pressable onPress={() => navigation.navigate('NewAddressScreen')}>
-          <PlusIcon size={24} color={theme.global.accent} style={{ marginRight: 20 }} />
-        </Pressable>
-      )
-    })
-  })
 
   useFocusEffect(
     useCallback(() => {


### PR DESCRIPTION
Closes #64

For reasons I don't fully comprehend, moving the `HeaderRight` component of the `AddressesScreenHeader` to its own file fixed this issue. Specifically, the issue was the `useTheme` and `useNavigation` inside the `AddressesScreenHeader`. When those were moved only to the place where they were needed, the warning/error disappeared.