### PR TITLE
Improve navigation UX

### DIFF
--- a/src/navigation/RootStackNavigation.tsx
+++ b/src/navigation/RootStackNavigation.tsx
@@ -23,7 +23,7 @@ import { useWindowDimensions } from 'react-native'
 import { useTheme } from 'styled-components'
 
 import useBottomModalOptions from '../hooks/layout/useBottomModalOptions'
-import { useAppDispatch, useAppSelector } from '../hooks/redux'
+import { useAppDispatch } from '../hooks/redux'
 import AddressScreen from '../screens/AddressScreen'
 import EditAddressScreen from '../screens/EditAddressScreen'
 import LandingScreen from '../screens/LandingScreen'
@@ -45,7 +45,7 @@ import SwitchWalletAfterDeletionScreen from '../screens/SwitchWalletAfterDeletio
 import SwitchWalletScreen from '../screens/SwitchWalletScreen'
 import TransactionScreen from '../screens/TransactionScreen'
 import { routeChanged } from '../store/appMetadataSlice'
-import { rootStackNavigationRef } from '../utils/navigation'
+import { isNavStateRestorable, rootStackNavigationRef } from '../utils/navigation'
 import InWalletTabsNavigation from './InWalletNavigation'
 import RootStackParamList from './rootStackRoutes'
 
@@ -57,10 +57,9 @@ const RootStackNavigation = () => {
   const { height: screenHeight } = useWindowDimensions()
   const smallBottomModalOptions = useBottomModalOptions({ height: screenHeight - 460 })
   const dispatch = useAppDispatch()
-  const isAuthenticated = !!useAppSelector((state) => state.activeWallet.mnemonic)
 
   const handleStateChange = (state?: NavigationState) => {
-    if (state && isAuthenticated) dispatch(routeChanged(state))
+    if (state && isNavStateRestorable(state)) dispatch(routeChanged(state))
   }
 
   const themeNavigator = {

--- a/src/screens/SwitchWalletScreen.tsx
+++ b/src/screens/SwitchWalletScreen.tsx
@@ -26,7 +26,7 @@ import styled, { useTheme } from 'styled-components/native'
 import AppText from '../components/AppText'
 import Button from '../components/buttons/Button'
 import ButtonsRow from '../components/buttons/ButtonsRow'
-import { BottomModalScreenTitle, BottomScreenSection, ScreenSection } from '../components/layout/Screen'
+import Screen, { BottomModalScreenTitle, BottomScreenSection, ScreenSection } from '../components/layout/Screen'
 import RadioButtonRow from '../components/RadioButtonRow'
 import SpinnerModal from '../components/SpinnerModal'
 import { useAppDispatch, useAppSelector } from '../hooks/redux'
@@ -81,7 +81,7 @@ const SwitchWalletScreen = ({ navigation, style }: SwitchWalletScreenProps) => {
   }
 
   return (
-    <>
+    <Screen style={style}>
       <ScreenSection>
         <BottomModalScreenTitle>Wallets</BottomModalScreenTitle>
         <Subtitle>Switch to another wallet?</Subtitle>
@@ -116,7 +116,7 @@ const SwitchWalletScreen = ({ navigation, style }: SwitchWalletScreenProps) => {
         </ButtonsRow>
       </BottomScreenSection>
       <SpinnerModal isActive={loading} text="Switching wallets..." />
-    </>
+    </Screen>
   )
 }
 

--- a/src/screens/SwitchWalletScreen.tsx
+++ b/src/screens/SwitchWalletScreen.tsx
@@ -16,7 +16,7 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { getHumanReadableError } from '@alephium/sdk'
+import { getHumanReadableError, walletOpenAsyncUnsafe } from '@alephium/sdk'
 import { StackScreenProps } from '@react-navigation/stack'
 import { ArrowDown as ArrowDownIcon, Plus as PlusIcon } from 'lucide-react-native'
 import { useEffect, useState } from 'react'
@@ -28,12 +28,15 @@ import Button from '../components/buttons/Button'
 import ButtonsRow from '../components/buttons/ButtonsRow'
 import { BottomModalScreenTitle, BottomScreenSection, ScreenSection } from '../components/layout/Screen'
 import RadioButtonRow from '../components/RadioButtonRow'
+import SpinnerModal from '../components/SpinnerModal'
 import { useAppDispatch, useAppSelector } from '../hooks/redux'
 import RootStackParamList from '../navigation/rootStackRoutes'
 import { getStoredWalletById, getWalletsMetadata } from '../storage/wallets'
 import { activeWalletChanged } from '../store/activeWalletSlice'
 import { methodSelected, WalletGenerationMethod } from '../store/walletGenerationSlice'
 import { WalletMetadata } from '../types/wallet'
+import { mnemonicToSeed, pbkdf2 } from '../utils/crypto'
+import { useRestoreNavigationState } from '../utils/navigation'
 
 export interface SwitchWalletScreenProps extends StackScreenProps<RootStackParamList, 'SwitchWalletScreen'> {
   style?: StyleProp<ViewStyle>
@@ -43,7 +46,9 @@ const SwitchWalletScreen = ({ navigation, style }: SwitchWalletScreenProps) => {
   const dispatch = useAppDispatch()
   const wallets = useSortedWallets()
   const theme = useTheme()
-  const activeWalletMetadataId = useAppSelector((state) => state.activeWallet.metadataId)
+  const [activeWalletMetadataId, pin] = useAppSelector((s) => [s.activeWallet.metadataId, s.credentials.pin])
+  const restoreNavigationState = useRestoreNavigationState()
+  const [loading, setLoading] = useState(false)
 
   const handleButtonPress = (method: WalletGenerationMethod) => {
     dispatch(methodSelected(method))
@@ -51,20 +56,27 @@ const SwitchWalletScreen = ({ navigation, style }: SwitchWalletScreenProps) => {
   }
 
   const handleWalletItemPress = async (walletId: string) => {
+    setLoading(true)
+
     try {
       const storedWallet = await getStoredWalletById(walletId)
 
       if (storedWallet.authType === 'pin') {
-        navigation.navigate('LoginScreen', { walletIdToLogin: walletId, resetNavigationOnLogin: true })
-        return
-      }
-
-      if (storedWallet.authType === 'biometrics') {
+        if (pin) {
+          const decryptedWallet = await walletOpenAsyncUnsafe(pin, storedWallet.mnemonic, pbkdf2, mnemonicToSeed)
+          dispatch(activeWalletChanged({ ...storedWallet, mnemonic: decryptedWallet.mnemonic }))
+          restoreNavigationState(true)
+        } else {
+          navigation.navigate('LoginScreen', { walletIdToLogin: walletId, resetNavigationOnLogin: true })
+        }
+      } else if (storedWallet.authType === 'biometrics') {
         dispatch(activeWalletChanged(storedWallet))
         navigation.navigate('InWalletScreen')
       }
     } catch (e) {
       Alert.alert(getHumanReadableError(e, 'Could not switch wallets'))
+    } finally {
+      setLoading(false)
     }
   }
 
@@ -103,6 +115,7 @@ const SwitchWalletScreen = ({ navigation, style }: SwitchWalletScreenProps) => {
           />
         </ButtonsRow>
       </BottomScreenSection>
+      <SpinnerModal isActive={loading} text="Switching wallets..." />
     </>
   )
 }

--- a/src/utils/navigation.ts
+++ b/src/utils/navigation.ts
@@ -17,6 +17,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { createNavigationContainerRef } from '@react-navigation/native'
+import { NavigationState } from '@react-navigation/routers'
 import { StackScreenProps } from '@react-navigation/stack'
 import { useCallback } from 'react'
 
@@ -37,12 +38,21 @@ const initialNavigationState = {
 // well as the RootStackNavigation itself.
 export const rootStackNavigationRef = createNavigationContainerRef<RootStackParamList>()
 
+const excludedRoutesFromRestoring = ['SplashScreen', 'LoginScreen']
+
+export const isNavStateRestorable = (state: NavigationState) => {
+  const routes = state.routes.map((route) => route.name)
+  const latestRoute = routes.length > 0 ? routes[routes.length - 1] : undefined
+
+  return latestRoute && !excludedRoutesFromRestoring.includes(latestRoute)
+}
+
 export const useRestoreNavigationState = () => {
   const lastNavigationState = useAppSelector((state) => state.appMetadata.lastNavigationState)
 
   const restoreNavigationState = useCallback(
     (reset?: boolean) => {
-      const resetNavigationState = reset || !lastNavigationState
+      const resetNavigationState = reset || !lastNavigationState || !isNavStateRestorable(lastNavigationState)
 
       rootStackNavigationRef.resetRoot(resetNavigationState ? initialNavigationState : lastNavigationState)
     },


### PR DESCRIPTION
This PR improves 2 things:
- When switching wallets, if the user is already authenticated and the pin is in memory, there's no point in asking the user to enter it again. The pin is only asked when the app goes to the background and the memory is flushed.
- On a fresh install, while the user hasn't yet created a wallet, if the app went to the background the user had to restart the wallet creation process from scratch. I can imagine this would be a pain in the 🍑 if someone had to switch apps to see their mnemonic, see a pin stored in a password managed, etc. This PR solves that problem by updating and restoring the navigation state in these cases as well.