### PR TITLE
Add 4 Fiat Currency Into Mobile Wallet

### DIFF
--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -18,7 +18,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 
 import { ThemeType } from '~/style/themes'
 
-export type Currency = 'CHF' | 'GBP' | 'EUR' | 'USD' | 'TRY' | 'VND' | 'RUB' | 'IDR
+export type Currency = 'CHF' | 'GBP' | 'EUR' | 'USD' | 'TRY' | 'VND' | 'RUB' | 'IDR' 
 
 export interface GeneralSettings {
   theme: ThemeType

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -18,7 +18,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 
 import { ThemeType } from '~/style/themes'
 
-export type Currency = 'CHF' | 'GBP' | 'EUR' | 'USD'
+export type Currency = 'CHF' | 'GBP' | 'EUR' | 'USD' | 'TRY' | 'VND' | 'RUB' | 'IDR
 
 export interface GeneralSettings {
   theme: ThemeType

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -18,7 +18,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 
 import { ThemeType } from '~/style/themes'
 
-export type Currency = 'CHF' | 'GBP' | 'EUR' | 'USD' | 'TRY' | 'VND' | 'RUB' | 'IDR' 
+export type Currency = 'CHF' | 'GBP' | 'EUR' | 'USD' | 'TRY' | 'VND' | 'RUB' | 'IDR'
 
 export interface GeneralSettings {
   theme: ThemeType

--- a/src/utils/currencies.ts
+++ b/src/utils/currencies.ts
@@ -44,5 +44,25 @@ export const currencies: Record<Currency, CurrencyData> = {
     name: 'United States Dollar',
     ticker: 'USD',
     symbol: '$'
+  },
+  TRY: {
+    name: 'Turkish Lira',
+    ticker: 'TRY',
+    symbol: '₺'
+  },
+  VND: {
+    name: 'Vietnamese Dong',
+    ticker: 'VND',
+    symbol: '₫'
+  },
+  RUB: {
+    name: 'Russian Ruble',
+    ticker: 'RUB',
+    symbol: '₽'
+  },
+  IDR: {
+    name: 'Rupiah',
+    ticker: 'IDR',
+    symbol: 'Rp'
   }
 }


### PR DESCRIPTION
Hey. I add 4 fiat currency in to mobile wallet
1. IDR = Indonesian Rupiahs
2. TRY = Turkish Lira
3. RUB = Russian Ruble
4. VND = Vietnamese Dong

its same as desktop wallet currency support
Thanks