### PR TITLE
Scrollable modals

### DIFF
--- a/src/components/AddressBox.tsx
+++ b/src/components/AddressBox.tsx
@@ -33,8 +33,6 @@ import { AddressHash } from '~/types/addresses'
 interface AddressBoxProps extends PressableProps {
   addressHash: AddressHash
   isSelected?: boolean
-  isFirst?: boolean
-  isLast?: boolean
 }
 
 const AnimatedPressable = Animated.createAnimatedComponent(Pressable)

--- a/src/components/AddressFlatList.tsx
+++ b/src/components/AddressFlatList.tsx
@@ -16,37 +16,44 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import styled from 'styled-components/native'
+import { FlatList } from 'react-native-gesture-handler'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
 import AddressBox from '~/components/AddressBox'
-import { ScreenSection } from '~/components/layout/Screen'
 import { ScrollScreenProps } from '~/components/layout/ScrollScreen'
 import { useAppSelector } from '~/hooks/redux'
 import { selectAllAddresses } from '~/store/addressesSlice'
+import { VERTICAL_GAP } from '~/style/globalStyle'
 import { AddressHash } from '~/types/addresses'
 
-export interface AddressListScreenBaseProps extends ScrollScreenProps {
+export interface AddressFlatListProps extends ScrollScreenProps {
   onAddressPress: (addressHash: AddressHash) => void
 }
 
-// TODO: Should be converted to a FlatList
-
-const AddressListScreenBase = ({ onAddressPress, ...props }: AddressListScreenBaseProps) => {
+const AddressFlatList = ({ onAddressPress, ...props }: AddressFlatListProps) => {
   const addresses = useAppSelector(selectAllAddresses)
+  const insets = useSafeAreaInsets()
 
   return (
-    <ScreenSection>
-      <AddressList>
-        {addresses.map((address) => (
-          <AddressBox key={address.hash} addressHash={address.hash} onPress={() => onAddressPress(address.hash)} />
-        ))}
-      </AddressList>
-    </ScreenSection>
+    <FlatList
+      data={addresses}
+      style={{ marginBottom: insets.bottom + insets.top }}
+      keyExtractor={(item) => item.hash}
+      contentContainerStyle={{ gap: VERTICAL_GAP }}
+      renderItem={({ item: address, index }) => (
+        <AddressBox
+          key={address.hash}
+          addressHash={address.hash}
+          style={{
+            marginTop: index === 0 ? 20 : undefined,
+            marginBottom: index === addresses.length - 1 ? 40 : undefined
+          }}
+          onPress={() => onAddressPress(address.hash)}
+        />
+      )}
+      {...props}
+    />
   )
 }
 
-export default AddressListScreenBase
-
-const AddressList = styled.View`
-  gap: 20px;
-`
+export default AddressFlatList

--- a/src/components/layout/BottomModal.tsx
+++ b/src/components/layout/BottomModal.tsx
@@ -56,13 +56,13 @@ interface BottomModalProps {
   Content: (props: ModalContentProps) => ReactNode
   isOpen: boolean
   onClose: () => void
-  scrollableContent?: boolean
+  maximisedContent?: boolean
   customMinHeight?: number
 }
 
 const AnimatedPressable = Animated.createAnimatedComponent(Pressable)
 
-const BottomModal = ({ Content, isOpen, onClose, scrollableContent, customMinHeight }: BottomModalProps) => {
+const BottomModal = ({ Content, isOpen, onClose, maximisedContent, customMinHeight }: BottomModalProps) => {
   const insets = useSafeAreaInsets()
 
   const [dimensions, setDimensions] = useState(Dimensions.get('window'))
@@ -101,7 +101,7 @@ const BottomModal = ({ Content, isOpen, onClose, scrollableContent, customMinHei
   }))
 
   const handleAnimatedStyle = useAnimatedStyle(() => ({
-    opacity: scrollableContent ? 0 : interpolate(-modalHeight.value, [0, minHeight.value, dimensions.height], [0, 1, 0])
+    opacity: maximisedContent ? 0 : interpolate(-modalHeight.value, [0, minHeight.value, dimensions.height], [0, 1, 0])
   }))
 
   const backdropAnimatedStyle = useAnimatedStyle(() => ({
@@ -122,13 +122,13 @@ const BottomModal = ({ Content, isOpen, onClose, scrollableContent, customMinHei
 
         minHeight.value = customMinHeight
           ? customMinHeight
-          : scrollableContent
+          : maximisedContent
           ? maxHeight
           : canMaximize.value
           ? dimensions.height * 0.3
           : contentHeight.value + NAV_HEIGHT + insets.bottom + VERTICAL_GAP
 
-        scrollableContent ? handleMaximize() : handleMinimize()
+        maximisedContent ? handleMaximize() : handleMinimize()
       })()
     }
   }
@@ -180,7 +180,7 @@ const BottomModal = ({ Content, isOpen, onClose, scrollableContent, customMinHei
           if (shouldMaximise) {
             handleMaximize()
           } else if (shouldMinimise) {
-            scrollableContent ? handleClose() : handleMinimize()
+            maximisedContent ? handleClose() : handleMinimize()
           } else if (shouldClose) {
             handleClose()
           } else {
@@ -201,7 +201,7 @@ const BottomModal = ({ Content, isOpen, onClose, scrollableContent, customMinHei
       modalHeight,
       offsetY,
       position.value,
-      scrollableContent
+      maximisedContent
     ]
   )
 

--- a/src/components/layout/BottomModal.tsx
+++ b/src/components/layout/BottomModal.tsx
@@ -87,13 +87,22 @@ const BottomModal = ({ Content, isOpen, onClose, maximisedContent, customMinHeig
 
   const canMaximize = useSharedValue(false)
 
-  const modalHeightAnimatedStyle = useAnimatedStyle(() => ({
-    height: -modalHeight.value,
-    paddingTop:
-      position.value === 'maximised' ? insets.top : position.value === 'closing' ? withSpring(0, springConfig) : 20,
-    marginRight: interpolate(-modalHeight.value, [minHeight.value, dimensions.height], [5, 0], Extrapolate.CLAMP),
-    marginLeft: interpolate(-modalHeight.value, [minHeight.value, dimensions.height], [5, 0], Extrapolate.CLAMP)
-  }))
+  const modalHeightAnimatedStyle = useAnimatedStyle(() => {
+    const margin = interpolate(
+      -modalHeight.value,
+      [maximisedContent ? 0 : minHeight.value, dimensions.height],
+      [5, 0],
+      Extrapolate.CLAMP
+    )
+
+    return {
+      height: -modalHeight.value,
+      paddingTop:
+        position.value === 'maximised' ? insets.top : position.value === 'closing' ? withSpring(0, springConfig) : 20,
+      marginRight: margin,
+      marginLeft: margin
+    }
+  })
 
   const modalNavigationAnimatedStyle = useAnimatedStyle(() => ({
     height: navHeight.value,

--- a/src/components/layout/BottomModal.tsx
+++ b/src/components/layout/BottomModal.tsx
@@ -124,8 +124,6 @@ const BottomModal = ({ Content, isOpen, onClose, maximisedContent, customMinHeig
           ? customMinHeight
           : maximisedContent
           ? maxHeight
-          : canMaximize.value
-          ? dimensions.height * 0.3
           : contentHeight.value + NAV_HEIGHT + insets.bottom + VERTICAL_GAP
 
         maximisedContent ? handleMaximize() : handleMinimize()

--- a/src/components/layout/ModalContent.tsx
+++ b/src/components/layout/ModalContent.tsx
@@ -17,33 +17,35 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { ReactNode } from 'react'
-import { ViewProps } from 'react-native'
+import { FlatListProps, ScrollViewProps } from 'react-native'
+import { FlatList as GHFlatList, ScrollView as GHScrollView } from 'react-native-gesture-handler'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
-import styled from 'styled-components/native'
 
 import Screen, { ScreenProps } from '~/components/layout/Screen'
 import ScrollSection, { ScrollSectionProps } from '~/components/layout/ScrollSection'
 import { VERTICAL_GAP } from '~/style/globalStyle'
 
-export interface ModalContentProps extends ViewProps {
-  onLayout: ViewProps['onLayout']
+interface ModalContentBaseProps {
   onClose?: () => void
   isScrollable?: boolean
   children?: ReactNode
   verticalGap?: number | boolean
-  fill?: boolean
 }
 
-export const ModalContent = ({ children, verticalGap, fill, ...props }: ModalContentProps) => (
-  <ModalContentStyled
-    {...props}
-    style={{
-      gap: verticalGap ? (typeof verticalGap === 'number' ? verticalGap || 0 : VERTICAL_GAP) : 0,
-      flex: fill ? 1 : undefined
-    }}
-  >
+export interface ModalContentProps extends ModalContentBaseProps, ScrollViewProps {}
+
+export interface ModalFlatListContentProps<T> extends ModalContentBaseProps, FlatListProps<T> {}
+
+export const ModalContent = ({ children, verticalGap, ...props }: ModalContentProps) => (
+  <GHScrollView {...getDefaultProps({ verticalGap })} {...props}>
     {children}
-  </ModalContentStyled>
+  </GHScrollView>
+)
+
+export const ModalFlatListContent = <T,>({ children, verticalGap, ...props }: ModalFlatListContentProps<T>) => (
+  <GHFlatList {...getDefaultProps({ verticalGap })} {...props}>
+    {children}
+  </GHFlatList>
 )
 
 export const Modal = ({ children, style, ...props }: ScreenProps) => {
@@ -66,7 +68,15 @@ export const ScrollModal = ({ children, style, ...props }: ScrollSectionProps) =
   )
 }
 
-const ModalContentStyled = styled.View`
-  padding-top: 10px;
-  padding-bottom: 10px;
-`
+const getDefaultProps = ({ verticalGap, contentContainerStyle }: ModalContentProps) => ({
+  bounces: false,
+  scrollEventThrottle: 16,
+  contentContainerStyle: [
+    {
+      gap: verticalGap ? (typeof verticalGap === 'number' ? verticalGap || 0 : VERTICAL_GAP) : 0,
+      paddingTop: 10,
+      paddingBottom: 20
+    },
+    contentContainerStyle
+  ]
+})

--- a/src/components/layout/ModalContent.tsx
+++ b/src/components/layout/ModalContent.tsx
@@ -36,6 +36,8 @@ export interface ModalContentProps extends ModalContentBaseProps, ScrollViewProp
 
 export interface ModalFlatListContentProps<T> extends ModalContentBaseProps, FlatListProps<T> {}
 
+const scrollDefaultProps = { bounces: false, scrollEventThrottle: 16 }
+
 export const ModalContent = ({
   children,
   verticalGap,
@@ -43,8 +45,10 @@ export const ModalContent = ({
   contentContainerStyle,
   ...props
 }: ModalContentProps) => (
-  <GHScrollView {...getDefaultProps({ verticalGap, contentContainerStyle })} {...props}>
-    <View onLayout={onLayout}>{children}</View>
+  <GHScrollView {...scrollDefaultProps} {...props}>
+    <View onLayout={onLayout} style={getDefaultContentContainerStyle({ verticalGap, contentContainerStyle })}>
+      {children}
+    </View>
   </GHScrollView>
 )
 
@@ -54,7 +58,11 @@ export const ModalFlatListContent = <T,>({
   contentContainerStyle,
   ...props
 }: ModalFlatListContentProps<T>) => (
-  <GHFlatList {...getDefaultProps({ verticalGap, contentContainerStyle })} {...props}>
+  <GHFlatList
+    contentContainerStyle={getDefaultContentContainerStyle({ verticalGap, contentContainerStyle })}
+    {...scrollDefaultProps}
+    {...props}
+  >
     {children}
   </GHFlatList>
 )
@@ -79,15 +87,11 @@ export const ScrollModal = ({ children, style, ...props }: ScrollSectionProps) =
   )
 }
 
-const getDefaultProps = ({ verticalGap, contentContainerStyle }: ModalContentProps) => ({
-  bounces: false,
-  scrollEventThrottle: 16,
-  contentContainerStyle: [
-    {
-      gap: verticalGap ? (typeof verticalGap === 'number' ? verticalGap || 0 : VERTICAL_GAP) : 0,
-      paddingTop: 10,
-      paddingBottom: 20
-    },
-    contentContainerStyle
-  ]
-})
+const getDefaultContentContainerStyle = ({ verticalGap, contentContainerStyle }: ModalContentProps) => [
+  {
+    gap: verticalGap ? (typeof verticalGap === 'number' ? verticalGap || 0 : VERTICAL_GAP) : 0,
+    paddingTop: 10,
+    paddingBottom: 20
+  },
+  contentContainerStyle
+]

--- a/src/components/layout/ModalContent.tsx
+++ b/src/components/layout/ModalContent.tsx
@@ -36,14 +36,25 @@ export interface ModalContentProps extends ModalContentBaseProps, ScrollViewProp
 
 export interface ModalFlatListContentProps<T> extends ModalContentBaseProps, FlatListProps<T> {}
 
-export const ModalContent = ({ children, verticalGap, onLayout, ...props }: ModalContentProps) => (
-  <GHScrollView {...getDefaultProps({ verticalGap })} {...props}>
+export const ModalContent = ({
+  children,
+  verticalGap,
+  onLayout,
+  contentContainerStyle,
+  ...props
+}: ModalContentProps) => (
+  <GHScrollView {...getDefaultProps({ verticalGap, contentContainerStyle })} {...props}>
     <View onLayout={onLayout}>{children}</View>
   </GHScrollView>
 )
 
-export const ModalFlatListContent = <T,>({ children, verticalGap, ...props }: ModalFlatListContentProps<T>) => (
-  <GHFlatList {...getDefaultProps({ verticalGap })} {...props}>
+export const ModalFlatListContent = <T,>({
+  children,
+  verticalGap,
+  contentContainerStyle,
+  ...props
+}: ModalFlatListContentProps<T>) => (
+  <GHFlatList {...getDefaultProps({ verticalGap, contentContainerStyle })} {...props}>
     {children}
   </GHFlatList>
 )

--- a/src/components/layout/ModalContent.tsx
+++ b/src/components/layout/ModalContent.tsx
@@ -17,7 +17,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { ReactNode } from 'react'
-import { FlatListProps, ScrollViewProps } from 'react-native'
+import { FlatListProps, ScrollViewProps, View } from 'react-native'
 import { FlatList as GHFlatList, ScrollView as GHScrollView } from 'react-native-gesture-handler'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
@@ -36,9 +36,9 @@ export interface ModalContentProps extends ModalContentBaseProps, ScrollViewProp
 
 export interface ModalFlatListContentProps<T> extends ModalContentBaseProps, FlatListProps<T> {}
 
-export const ModalContent = ({ children, verticalGap, ...props }: ModalContentProps) => (
+export const ModalContent = ({ children, verticalGap, onLayout, ...props }: ModalContentProps) => (
   <GHScrollView {...getDefaultProps({ verticalGap })} {...props}>
-    {children}
+    <View onLayout={onLayout}>{children}</View>
   </GHScrollView>
 )
 

--- a/src/components/layout/TransactionsFlatListScreen.tsx
+++ b/src/components/layout/TransactionsFlatListScreen.tsx
@@ -181,7 +181,6 @@ const TransactionsFlatListScreen = forwardRef(function TransactionsFlatListScree
           Content={(props) => selectedTx && <TransactionModal {...props} tx={selectedTx} />}
           isOpen={txModalOpen}
           onClose={() => setTxModalOpen(false)}
-          customMinHeight={300}
         />
       </Portal>
     </Screen>

--- a/src/screens/Address/EditAddressModal.tsx
+++ b/src/screens/Address/EditAddressModal.tsx
@@ -65,7 +65,7 @@ const EditAddressModal = ({ addressHash, onClose, ...props }: EditAddressModalPr
   }
 
   return (
-    <ModalContent fill verticalGap {...props}>
+    <ModalContent verticalGap {...props}>
       <ScreenSection>
         <BottomModalScreenTitle>Address settings</BottomModalScreenTitle>
         <HashEllipsed numberOfLines={1} ellipsizeMode="middle" color="secondary">

--- a/src/screens/Addresses/AddressesScreen.tsx
+++ b/src/screens/Addresses/AddressesScreen.tsx
@@ -152,7 +152,6 @@ const AddressesScreen = ({ onScroll, contentStyle, ...props }: BottomBarScrollSc
         <BottomModal
           isOpen={isAddressSettingsModalOpen}
           onClose={() => setIsAddressSettingsModalOpen(false)}
-          maximisedContent
           Content={(props) => <EditAddressModal addressHash={selectedAddress.hash} {...props} />}
         />
       </Portal>

--- a/src/screens/Addresses/AddressesScreen.tsx
+++ b/src/screens/Addresses/AddressesScreen.tsx
@@ -20,25 +20,22 @@ import { NavigationProp, useNavigation } from '@react-navigation/native'
 import { usePostHog } from 'posthog-react-native'
 import { useEffect, useState } from 'react'
 import { View } from 'react-native'
-import { FlatList } from 'react-native-gesture-handler'
 import { Portal } from 'react-native-portalize'
 import Animated from 'react-native-reanimated'
-import { useSafeAreaInsets } from 'react-native-safe-area-context'
-import styled, { css, useTheme } from 'styled-components/native'
+import styled, { useTheme } from 'styled-components/native'
 
-import AddressBox from '~/components/AddressBox'
 import AddressCard from '~/components/AddressCard'
 import AddressesTokensList from '~/components/AddressesTokensList'
 import Button from '~/components/buttons/Button'
 import Carousel from '~/components/Carousel'
 import BottomBarScrollScreen, { BottomBarScrollScreenProps } from '~/components/layout/BottomBarScrollScreen'
 import BottomModal from '~/components/layout/BottomModal'
-import { ModalContent } from '~/components/layout/ModalContent'
 import { TabBarPageProps } from '~/components/layout/TabBarPager'
 import RefreshSpinner from '~/components/RefreshSpinner'
 import { useAppDispatch, useAppSelector } from '~/hooks/redux'
 import RootStackParamList from '~/navigation/rootStackRoutes'
 import EditAddressModal from '~/screens/Address/EditAddressModal'
+import SelectAddressModal from '~/screens/SendReceive/Send/SelectAddressModal'
 import {
   selectAddressByHash,
   selectAddressIds,
@@ -46,14 +43,12 @@ import {
   selectDefaultAddress,
   syncAddressesData
 } from '~/store/addressesSlice'
-import { VERTICAL_GAP } from '~/style/globalStyle'
 import { AddressHash } from '~/types/addresses'
 
 const AddressesScreen = ({ onScroll, contentStyle, ...props }: BottomBarScrollScreenProps & TabBarPageProps) => {
   const dispatch = useAppDispatch()
   const theme = useTheme()
   const posthog = usePostHog()
-  const insets = useSafeAreaInsets()
   const navigation = useNavigation<NavigationProp<RootStackParamList>>()
 
   const isLoading = useAppSelector((s) => s.addresses.syncingAddressData)
@@ -142,29 +137,15 @@ const AddressesScreen = ({ onScroll, contentStyle, ...props }: BottomBarScrollSc
           onClose={() => setIsQuickSelectionModalOpen(false)}
           scrollableContent
           Content={(props) => (
-            <ModalContent {...props}>
-              <FlatList
-                data={addresses}
-                style={{ marginBottom: insets.bottom + insets.top }}
-                keyExtractor={(item) => item.hash}
-                contentContainerStyle={{ gap: VERTICAL_GAP }}
-                canCancelContentTouches={true}
-                renderItem={({ item: address, index }) => (
-                  <AddressBoxStyled
-                    key={address.hash}
-                    addressHash={address.hash}
-                    isFirst={index === 0}
-                    isLast={index === addresses.length - 1}
-                    onPress={() => {
-                      setSelectedAddressHash(address.hash)
-                      setScrollToCarouselPage(addressHashes.findIndex((hash) => hash === address.hash))
-                      props.onClose && props.onClose()
-                      posthog?.capture('Used address quick navigation')
-                    }}
-                  />
-                )}
-              />
-            </ModalContent>
+            <SelectAddressModal
+              onAddressPress={(addressHash) => {
+                setSelectedAddressHash(addressHash)
+                setScrollToCarouselPage(addressHashes.findIndex((hash) => hash === addressHash))
+                props.onClose && props.onClose()
+                posthog?.capture('Used address quick navigation')
+              }}
+              {...props}
+            />
           )}
         />
 
@@ -184,20 +165,4 @@ export default AddressesScreen
 const Content = styled(Animated.View)`
   flex: 1;
   gap: 10px;
-`
-
-const AddressBoxStyled = styled(AddressBox)`
-  margin: 10px 20px;
-
-  ${({ isFirst }) =>
-    isFirst &&
-    css`
-      margin-top: 20px;
-    `}
-
-  ${({ isLast }) =>
-    isLast &&
-    css`
-      margin-bottom: 40px;
-    `}
 `

--- a/src/screens/Addresses/AddressesScreen.tsx
+++ b/src/screens/Addresses/AddressesScreen.tsx
@@ -135,7 +135,7 @@ const AddressesScreen = ({ onScroll, contentStyle, ...props }: BottomBarScrollSc
         <BottomModal
           isOpen={isQuickSelectionModalOpen}
           onClose={() => setIsQuickSelectionModalOpen(false)}
-          scrollableContent
+          maximisedContent
           Content={(props) => (
             <SelectAddressModal
               onAddressPress={(addressHash) => {
@@ -152,7 +152,7 @@ const AddressesScreen = ({ onScroll, contentStyle, ...props }: BottomBarScrollSc
         <BottomModal
           isOpen={isAddressSettingsModalOpen}
           onClose={() => setIsAddressSettingsModalOpen(false)}
-          scrollableContent
+          maximisedContent
           Content={(props) => <EditAddressModal addressHash={selectedAddress.hash} {...props} />}
         />
       </Portal>

--- a/src/screens/CurrencySelectModal.tsx
+++ b/src/screens/CurrencySelectModal.tsx
@@ -19,7 +19,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 import React from 'react'
 
 import BoxSurface from '~/components/layout/BoxSurface'
-import { ModalContentProps, ScrollModal } from '~/components/layout/ModalContent'
+import { ModalContent, ModalContentProps } from '~/components/layout/ModalContent'
 import { ScreenSection } from '~/components/layout/Screen'
 import RadioButtonRow from '~/components/RadioButtonRow'
 import { useAppDispatch, useAppSelector } from '~/hooks/redux'
@@ -42,7 +42,7 @@ const CurrencySelectModal = ({ onClose, ...props }: ModalContentProps) => {
   }
 
   return (
-    <ScrollModal {...props}>
+    <ModalContent verticalGap {...props}>
       <ScreenSection>
         <BoxSurface>
           {currencyOptions.map((currencyOption) => (
@@ -55,7 +55,7 @@ const CurrencySelectModal = ({ onClose, ...props }: ModalContentProps) => {
           ))}
         </BoxSurface>
       </ScreenSection>
-    </ScrollModal>
+    </ModalContent>
   )
 }
 

--- a/src/screens/SecurityScreen.tsx
+++ b/src/screens/SecurityScreen.tsx
@@ -90,9 +90,9 @@ const SecurityScreen = ({ navigation, ...props }: SecurityScreenProps) => {
         <BottomModal
           isOpen={showMnemonic}
           onClose={() => setShowMnemonic(false)}
-          scrollableContent
+          maximisedContent
           Content={(props) => (
-            <ModalContent fill {...props}>
+            <ModalContent {...props}>
               <ScreenSection fill>
                 <OrderedTable items={mnemonic.split(' ')} />
               </ScreenSection>

--- a/src/screens/SendReceive/Receive/AddressScreen.tsx
+++ b/src/screens/SendReceive/Receive/AddressScreen.tsx
@@ -53,6 +53,8 @@ const AddressScreen = ({ navigation, ...props }: ScreenProps) => {
     }, [navigation])
   )
 
+  // TODO: Use FlatList (maybe AddressFlatList)
+
   return (
     <ScrollScreen hasHeader verticalGap {...props}>
       <ScreenIntro title="To address" subtitle="Select the address which you want to receive funds to." />

--- a/src/screens/SendReceive/Send/DestinationScreen.tsx
+++ b/src/screens/SendReceive/Send/DestinationScreen.tsx
@@ -247,7 +247,7 @@ const DestinationScreen = ({ navigation, route: { params }, ...props }: Destinat
           Content={(props) => <SelectAddressModal onAddressPress={handleAddressPress} {...props} />}
           onClose={() => setIsAddressSelectModalOpen(false)}
           customMinHeight={300}
-          scrollableContent
+          maximisedContent
         />
       </Portal>
     </>

--- a/src/screens/SendReceive/Send/DestinationScreen.tsx
+++ b/src/screens/SendReceive/Send/DestinationScreen.tsx
@@ -31,6 +31,7 @@ import styled, { useTheme } from 'styled-components/native'
 import Button from '~/components/buttons/Button'
 import Input from '~/components/inputs/Input'
 import BottomModal from '~/components/layout/BottomModal'
+import { ModalContentProps } from '~/components/layout/ModalContent'
 import { ScreenProps, ScreenSection } from '~/components/layout/Screen'
 import ScrollScreen from '~/components/layout/ScrollScreen'
 import QRCodeScannerModal from '~/components/QRCodeScannerModal'
@@ -100,22 +101,22 @@ const DestinationScreen = ({ navigation, route: { params }, ...props }: Destinat
     setTimeout(() => (shouldFlash.value = 0), 300)
   }
 
-  const handleContactPress = (contactId: Contact['id']) => {
+  const handleContactPress = (contactId: Contact['id'], closeModal?: ModalContentProps['onClose']) => {
     const contact = contacts.find((c) => c.id === contactId)
 
     if (contact) {
+      closeModal && closeModal()
       setToAddress(contact.address)
       flashInputBg()
-      setIsContactSelectModalOpen(false)
 
       posthog?.capture('Send: Selected contact to send funds to')
     }
   }
 
-  const handleAddressPress = (addressHash: AddressHash) => {
+  const handleAddressPress = (addressHash: AddressHash, closeModal?: ModalContentProps['onClose']) => {
+    closeModal && closeModal()
     setToAddress(addressHash)
     flashInputBg()
-    setIsAddressSelectModalOpen(false)
 
     posthog?.capture('Send: Selected own address to send funds to')
   }
@@ -230,7 +231,7 @@ const DestinationScreen = ({ navigation, route: { params }, ...props }: Destinat
           isOpen={isContactSelectModalOpen}
           Content={(props) => (
             <SelectContactModal
-              onContactPress={handleContactPress}
+              onContactPress={(contactId) => handleContactPress(contactId, props.onClose)}
               onNewContactPress={() => {
                 props.onClose && props.onClose()
                 navigation.navigate('NewContactScreen')
@@ -244,7 +245,12 @@ const DestinationScreen = ({ navigation, route: { params }, ...props }: Destinat
 
         <BottomModal
           isOpen={isAddressSelectModalOpen}
-          Content={(props) => <SelectAddressModal onAddressPress={handleAddressPress} {...props} />}
+          Content={(props) => (
+            <SelectAddressModal
+              onAddressPress={(addressHash) => handleAddressPress(addressHash, props.onClose)}
+              {...props}
+            />
+          )}
           onClose={() => setIsAddressSelectModalOpen(false)}
           customMinHeight={300}
           maximisedContent

--- a/src/screens/SendReceive/Send/OriginScreen.tsx
+++ b/src/screens/SendReceive/Send/OriginScreen.tsx
@@ -57,6 +57,8 @@ const OriginScreen = ({ navigation, route: { params }, ...props }: ScreenProps) 
     }, [defaultAddress, fromAddress, navigation, setFromAddress])
   )
 
+  // TODO: Use FlatList (maybe AddressFlatList)
+
   return (
     <ScrollScreen hasHeader verticalGap {...props}>
       <ScreenIntro title="Origin" subtitle="Select the address from which to send the transaction." />

--- a/src/screens/SendReceive/Send/SelectAddressModal.tsx
+++ b/src/screens/SendReceive/Send/SelectAddressModal.tsx
@@ -16,15 +16,15 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { ModalContentProps, ScrollModal } from '~/components/layout/ModalContent'
-import AddressListScreenBase, { AddressListScreenBaseProps } from '~/screens/AddressListScreenBase'
+import AddressFlatList, { AddressFlatListProps } from '~/components/AddressFlatList'
+import { ModalContent, ModalContentProps } from '~/components/layout/ModalContent'
 
-type SelectAddressModalProps = ModalContentProps & Pick<AddressListScreenBaseProps, 'onAddressPress'>
+type SelectAddressModalProps = ModalContentProps & Pick<AddressFlatListProps, 'onAddressPress'>
 
 const SelectAddressModal = ({ onAddressPress, ...props }: SelectAddressModalProps) => (
-  <ScrollModal {...props}>
-    <AddressListScreenBase onAddressPress={onAddressPress} />
-  </ScrollModal>
+  <ModalContent {...props}>
+    <AddressFlatList onAddressPress={onAddressPress} />
+  </ModalContent>
 )
 
 export default SelectAddressModal

--- a/src/screens/SendReceive/Send/SelectAddressModal.tsx
+++ b/src/screens/SendReceive/Send/SelectAddressModal.tsx
@@ -16,15 +16,36 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import AddressFlatList, { AddressFlatListProps } from '~/components/AddressFlatList'
-import { ModalContent, ModalContentProps } from '~/components/layout/ModalContent'
+import AddressBox from '~/components/AddressBox'
+import { AddressFlatListProps } from '~/components/AddressFlatList'
+import { ModalContentProps, ModalFlatListContent } from '~/components/layout/ModalContent'
+import { useAppSelector } from '~/hooks/redux'
+import { selectAllAddresses } from '~/store/addressesSlice'
 
 type SelectAddressModalProps = ModalContentProps & Pick<AddressFlatListProps, 'onAddressPress'>
 
-const SelectAddressModal = ({ onAddressPress, ...props }: SelectAddressModalProps) => (
-  <ModalContent {...props}>
-    <AddressFlatList onAddressPress={onAddressPress} />
-  </ModalContent>
-)
+const SelectAddressModal = ({ onAddressPress, ...props }: SelectAddressModalProps) => {
+  const addresses = useAppSelector(selectAllAddresses)
+
+  return (
+    <ModalFlatListContent
+      data={addresses}
+      verticalGap
+      keyExtractor={(item) => item.hash}
+      renderItem={({ item: address, index }) => (
+        <AddressBox
+          key={address.hash}
+          addressHash={address.hash}
+          style={{
+            marginTop: index === 0 ? 20 : undefined,
+            marginBottom: index === addresses.length - 1 ? 40 : undefined
+          }}
+          onPress={() => onAddressPress(address.hash)}
+        />
+      )}
+      {...props}
+    />
+  )
+}
 
 export default SelectAddressModal

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -187,14 +187,12 @@ const SettingsScreen = ({ navigation, ...props }: ScreenProps) => {
           isOpen={isSwitchNetworkModalOpen}
           onClose={() => setIsSwitchNetworkModalOpen(false)}
           Content={(props) => <SwitchNetworkModal onClose={() => setIsSwitchNetworkModalOpen(false)} {...props} />}
-          maximisedContent
         />
 
         <BottomModal
           isOpen={isCurrencySelectModalOpen}
           onClose={() => setIsCurrencySelectModalOpen(false)}
           Content={(props) => <CurrencySelectModal onClose={() => setIsCurrencySelectModalOpen(false)} {...props} />}
-          maximisedContent
         />
       </Portal>
     </>

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -187,14 +187,14 @@ const SettingsScreen = ({ navigation, ...props }: ScreenProps) => {
           isOpen={isSwitchNetworkModalOpen}
           onClose={() => setIsSwitchNetworkModalOpen(false)}
           Content={(props) => <SwitchNetworkModal onClose={() => setIsSwitchNetworkModalOpen(false)} {...props} />}
-          scrollableContent
+          maximisedContent
         />
 
         <BottomModal
           isOpen={isCurrencySelectModalOpen}
           onClose={() => setIsCurrencySelectModalOpen(false)}
           Content={(props) => <CurrencySelectModal onClose={() => setIsCurrencySelectModalOpen(false)} {...props} />}
-          scrollableContent
+          maximisedContent
         />
       </Portal>
     </>


### PR DESCRIPTION
- Every `ModalContent` is now an instance of `ScrollView` (from gesture handler)
- A new component called `ModalFlatListContent` can be used instead of `ModalContent` for rendering modals that include a `FlatList` (also from gesture handler)
- Unless the `maximisedContent` or the `customMinHeight` prop is set, the `BottomModal` will take the height of its contents.

~~This doesn't work well for minimized modals. Needs investigation.~~ It does!