### PR TITLE
Use scaled down left and right components in compact header

### DIFF
--- a/src/components/headers/StackHeader.tsx
+++ b/src/components/headers/StackHeader.tsx
@@ -28,15 +28,7 @@ const StackHeader = ({ navigation, options, ...props }: StackHeaderCustomProps) 
     <Button onPress={navigation.goBack} iconProps={{ name: 'arrow-back-outline' }} round />
   ) : null
 
-  const CompactContent = props.back ? <Button onPress={navigation.goBack} title="Back" type="transparent" /> : null
-
-  return (
-    <BaseHeader
-      options={{ headerLeft: () => HeaderLeft, ...options }}
-      headerCompactContent={() => CompactContent}
-      {...props}
-    />
-  )
+  return <BaseHeader options={{ headerLeft: () => HeaderLeft, ...options }} showCompactComponents {...props} />
 }
 
 export default StackHeader

--- a/src/components/layout/TabBarPager.tsx
+++ b/src/components/layout/TabBarPager.tsx
@@ -121,7 +121,7 @@ const TabBarPager = ({ pages, tabLabels, headerTitle, ...props }: TabBarScreenPr
             headerTitle
           }}
           headerBottom={() => <TabBar />}
-          headerCompactContent={() => <TabBar />}
+          showCompactComponents
         />
       </HeaderContainer>
     </>

--- a/src/screens/SendReceive/ProgressHeader.tsx
+++ b/src/screens/SendReceive/ProgressHeader.tsx
@@ -75,6 +75,7 @@ const ProgressHeader = ({ navigation, route, workflow, options }: ProgressHeader
         ),
         headerLeft: () => options.headerLeft && options.headerLeft({})
       }}
+      showCompactComponents
     />
   )
 }


### PR DESCRIPTION
I tried multiple implementations, but that's the easiest, lightest & most practical I came with.
This doesn't allow for customisation, but it works for now IMO. WDYT?