### PR TITLE
Fix ios android build

### DIFF
--- a/android/.gitignore
+++ b/android/.gitignore
@@ -13,3 +13,4 @@ local.properties
 
 # Bundle artifacts
 *.jsbundle
+.cxx

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -38,7 +38,7 @@ reactNativeArchitectures=armeabi-v7a,arm64-v8a,x86,x86_64
 # your application. You should enable this flag either if you want
 # to write custom TurboModules/Fabric components OR use libraries that
 # are providing them.
-newArchEnabled=true
+newArchEnabled=false
 
 # The hosted JavaScript engine
 # Supported values: expo.jsEngine = "hermes" | "jsc"

--- a/app.config.js
+++ b/app.config.js
@@ -55,6 +55,12 @@ export default {
           ios: {
             deploymentTarget: '13.0',
             newArchEnabled: false
+          },
+          android: {
+            compileSdkVersion: 33,
+            targetSdkVersion: 33,
+            buildToolsVersion: '33.0.0',
+            newArchEnabled: false
           }
         }
       ],

--- a/app.config.js
+++ b/app.config.js
@@ -53,7 +53,8 @@ export default {
         'expo-build-properties',
         {
           ios: {
-            deploymentTarget: '13.0'
+            deploymentTarget: '13.0',
+            newArchEnabled: false
           }
         }
       ],

--- a/ios/AlephiumWallet.xcodeproj/project.pbxproj
+++ b/ios/AlephiumWallet.xcodeproj/project.pbxproj
@@ -463,11 +463,11 @@
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = (
 					"$(inherited)",
-					"-DRN_FABRIC_ENABLED",
+					" ",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"$(inherited)",
-					"-DRN_FABRIC_ENABLED",
+					" ",
 				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
@@ -521,11 +521,11 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_CFLAGS = (
 					"$(inherited)",
-					"-DRN_FABRIC_ENABLED",
+					" ",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"$(inherited)",
-					"-DRN_FABRIC_ENABLED",
+					" ",
 				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -37,22 +37,9 @@ PODS:
     - expo-dev-menu-interface
     - ExpoModulesCore
     - EXUpdatesInterface
-    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Codegen
     - React-Core
-    - React-debug
-    - React-Fabric
-    - React-graphics
-    - React-NativeModulesApple
     - React-RCTAppDelegate
-    - React-RCTFabric
-    - React-utils
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - Yoga
   - expo-dev-launcher/Main (3.0.0):
     - EXManifests
     - expo-dev-launcher/Unsafe
@@ -60,116 +47,38 @@ PODS:
     - expo-dev-menu-interface
     - ExpoModulesCore
     - EXUpdatesInterface
-    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Codegen
     - React-Core
-    - React-debug
-    - React-Fabric
-    - React-graphics
-    - React-NativeModulesApple
     - React-RCTAppDelegate
-    - React-RCTFabric
-    - React-utils
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - Yoga
   - expo-dev-launcher/Unsafe (3.0.0):
     - EXManifests
     - expo-dev-menu
     - expo-dev-menu-interface
     - ExpoModulesCore
     - EXUpdatesInterface
-    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Codegen
     - React-Core
-    - React-debug
-    - React-Fabric
-    - React-graphics
-    - React-NativeModulesApple
     - React-RCTAppDelegate
-    - React-RCTFabric
-    - React-utils
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - Yoga
   - expo-dev-menu (4.0.0):
     - expo-dev-menu/Main (= 4.0.0)
-    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Codegen
     - React-Core
-    - React-debug
-    - React-Fabric
-    - React-graphics
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-utils
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - Yoga
   - expo-dev-menu-interface (1.3.0)
   - expo-dev-menu/Main (4.0.0):
     - EXManifests
     - expo-dev-menu-interface
     - expo-dev-menu/Vendored
     - ExpoModulesCore
-    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Codegen
     - React-Core
-    - React-debug
-    - React-Fabric
-    - React-graphics
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-utils
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - Yoga
   - expo-dev-menu/SafeAreaView (4.0.0):
     - ExpoModulesCore
-    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Codegen
     - React-Core
-    - React-debug
-    - React-Fabric
-    - React-graphics
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-utils
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - Yoga
   - expo-dev-menu/Vendored (4.0.0):
     - expo-dev-menu/SafeAreaView
-    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Codegen
     - React-Core
-    - React-debug
-    - React-Fabric
-    - React-graphics
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-utils
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - Yoga
   - ExpoBlur (12.4.1):
     - ExpoModulesCore
   - ExpoClipboard (4.3.1):
@@ -185,28 +94,24 @@ PODS:
   - ExpoLocalization (14.3.0):
     - ExpoModulesCore
   - ExpoModulesCore (1.5.9):
-    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Codegen
     - React-Core
-    - React-debug
-    - React-Fabric
-    - React-graphics
     - React-NativeModulesApple
     - React-RCTAppDelegate
-    - React-RCTFabric
-    - React-utils
-    - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - Yoga
   - ExpoSecureStore (12.3.1):
     - ExpoModulesCore
   - ExpoWebBrowser (12.3.2):
     - ExpoModulesCore
   - EXUpdatesInterface (0.11.0)
   - FBLazyVector (0.72.3)
+  - FBReactNativeSpec (0.72.3):
+    - RCT-Folly (= 2021.07.22.00)
+    - RCTRequired (= 0.72.3)
+    - RCTTypeSafety (= 0.72.3)
+    - React-Core (= 0.72.3)
+    - React-jsi (= 0.72.3)
+    - ReactCommon/turbomodule/core (= 0.72.3)
   - fmt (6.2.1)
   - glog (0.3.5)
   - hermes-engine (0.72.3):
@@ -224,11 +129,6 @@ PODS:
     - glog
     - RCT-Folly/Default (= 2021.07.22.00)
   - RCT-Folly/Default (2021.07.22.00):
-    - boost
-    - DoubleConversion
-    - fmt (~> 6.2.1)
-    - glog
-  - RCT-Folly/Fabric (2021.07.22.00):
     - boost
     - DoubleConversion
     - fmt (~> 6.2.1)
@@ -260,19 +160,17 @@ PODS:
   - React-callinvoker (0.72.3)
   - React-Codegen (0.72.3):
     - DoubleConversion
+    - FBReactNativeSpec
     - glog
     - hermes-engine
     - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-debug
-    - React-Fabric
-    - React-graphics
     - React-jsi
     - React-jsiexecutor
     - React-NativeModulesApple
-    - React-utils
+    - React-rncore
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
   - React-Core (0.72.3):
@@ -496,555 +394,6 @@ PODS:
     - React-perflogger (= 0.72.3)
     - React-runtimeexecutor (= 0.72.3)
   - React-debug (0.72.3)
-  - React-Fabric (0.72.3):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.3)
-    - RCTTypeSafety (= 0.72.3)
-    - React-Core
-    - React-debug
-    - React-Fabric/animations (= 0.72.3)
-    - React-Fabric/attributedstring (= 0.72.3)
-    - React-Fabric/butter (= 0.72.3)
-    - React-Fabric/componentregistry (= 0.72.3)
-    - React-Fabric/componentregistrynative (= 0.72.3)
-    - React-Fabric/components (= 0.72.3)
-    - React-Fabric/config (= 0.72.3)
-    - React-Fabric/core (= 0.72.3)
-    - React-Fabric/debug_renderer (= 0.72.3)
-    - React-Fabric/imagemanager (= 0.72.3)
-    - React-Fabric/leakchecker (= 0.72.3)
-    - React-Fabric/mapbuffer (= 0.72.3)
-    - React-Fabric/mounting (= 0.72.3)
-    - React-Fabric/scheduler (= 0.72.3)
-    - React-Fabric/telemetry (= 0.72.3)
-    - React-Fabric/templateprocessor (= 0.72.3)
-    - React-Fabric/textlayoutmanager (= 0.72.3)
-    - React-Fabric/uimanager (= 0.72.3)
-    - React-graphics (= 0.72.3)
-    - React-jsi (= 0.72.3)
-    - React-jsiexecutor (= 0.72.3)
-    - React-logger
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.3)
-  - React-Fabric/animations (0.72.3):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.3)
-    - RCTTypeSafety (= 0.72.3)
-    - React-Core
-    - React-debug
-    - React-graphics (= 0.72.3)
-    - React-jsi (= 0.72.3)
-    - React-jsiexecutor (= 0.72.3)
-    - React-logger
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.3)
-  - React-Fabric/attributedstring (0.72.3):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.3)
-    - RCTTypeSafety (= 0.72.3)
-    - React-Core
-    - React-debug
-    - React-graphics (= 0.72.3)
-    - React-jsi (= 0.72.3)
-    - React-jsiexecutor (= 0.72.3)
-    - React-logger
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.3)
-  - React-Fabric/butter (0.72.3):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.3)
-    - RCTTypeSafety (= 0.72.3)
-    - React-Core
-    - React-debug
-    - React-graphics (= 0.72.3)
-    - React-jsi (= 0.72.3)
-    - React-jsiexecutor (= 0.72.3)
-    - React-logger
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.3)
-  - React-Fabric/componentregistry (0.72.3):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.3)
-    - RCTTypeSafety (= 0.72.3)
-    - React-Core
-    - React-debug
-    - React-graphics (= 0.72.3)
-    - React-jsi (= 0.72.3)
-    - React-jsiexecutor (= 0.72.3)
-    - React-logger
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.3)
-  - React-Fabric/componentregistrynative (0.72.3):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.3)
-    - RCTTypeSafety (= 0.72.3)
-    - React-Core
-    - React-debug
-    - React-graphics (= 0.72.3)
-    - React-jsi (= 0.72.3)
-    - React-jsiexecutor (= 0.72.3)
-    - React-logger
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.3)
-  - React-Fabric/components (0.72.3):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.3)
-    - RCTTypeSafety (= 0.72.3)
-    - React-Core
-    - React-debug
-    - React-Fabric/components/activityindicator (= 0.72.3)
-    - React-Fabric/components/image (= 0.72.3)
-    - React-Fabric/components/inputaccessory (= 0.72.3)
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.72.3)
-    - React-Fabric/components/modal (= 0.72.3)
-    - React-Fabric/components/rncore (= 0.72.3)
-    - React-Fabric/components/root (= 0.72.3)
-    - React-Fabric/components/safeareaview (= 0.72.3)
-    - React-Fabric/components/scrollview (= 0.72.3)
-    - React-Fabric/components/text (= 0.72.3)
-    - React-Fabric/components/textinput (= 0.72.3)
-    - React-Fabric/components/unimplementedview (= 0.72.3)
-    - React-Fabric/components/view (= 0.72.3)
-    - React-graphics (= 0.72.3)
-    - React-jsi (= 0.72.3)
-    - React-jsiexecutor (= 0.72.3)
-    - React-logger
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.3)
-  - React-Fabric/components/activityindicator (0.72.3):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.3)
-    - RCTTypeSafety (= 0.72.3)
-    - React-Core
-    - React-debug
-    - React-graphics (= 0.72.3)
-    - React-jsi (= 0.72.3)
-    - React-jsiexecutor (= 0.72.3)
-    - React-logger
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.3)
-  - React-Fabric/components/image (0.72.3):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.3)
-    - RCTTypeSafety (= 0.72.3)
-    - React-Core
-    - React-debug
-    - React-graphics (= 0.72.3)
-    - React-jsi (= 0.72.3)
-    - React-jsiexecutor (= 0.72.3)
-    - React-logger
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.3)
-  - React-Fabric/components/inputaccessory (0.72.3):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.3)
-    - RCTTypeSafety (= 0.72.3)
-    - React-Core
-    - React-debug
-    - React-graphics (= 0.72.3)
-    - React-jsi (= 0.72.3)
-    - React-jsiexecutor (= 0.72.3)
-    - React-logger
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.3)
-  - React-Fabric/components/legacyviewmanagerinterop (0.72.3):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.3)
-    - RCTTypeSafety (= 0.72.3)
-    - React-Core
-    - React-debug
-    - React-graphics (= 0.72.3)
-    - React-jsi (= 0.72.3)
-    - React-jsiexecutor (= 0.72.3)
-    - React-logger
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.3)
-  - React-Fabric/components/modal (0.72.3):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.3)
-    - RCTTypeSafety (= 0.72.3)
-    - React-Core
-    - React-debug
-    - React-graphics (= 0.72.3)
-    - React-jsi (= 0.72.3)
-    - React-jsiexecutor (= 0.72.3)
-    - React-logger
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.3)
-  - React-Fabric/components/rncore (0.72.3):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.3)
-    - RCTTypeSafety (= 0.72.3)
-    - React-Core
-    - React-debug
-    - React-graphics (= 0.72.3)
-    - React-jsi (= 0.72.3)
-    - React-jsiexecutor (= 0.72.3)
-    - React-logger
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.3)
-  - React-Fabric/components/root (0.72.3):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.3)
-    - RCTTypeSafety (= 0.72.3)
-    - React-Core
-    - React-debug
-    - React-graphics (= 0.72.3)
-    - React-jsi (= 0.72.3)
-    - React-jsiexecutor (= 0.72.3)
-    - React-logger
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.3)
-  - React-Fabric/components/safeareaview (0.72.3):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.3)
-    - RCTTypeSafety (= 0.72.3)
-    - React-Core
-    - React-debug
-    - React-graphics (= 0.72.3)
-    - React-jsi (= 0.72.3)
-    - React-jsiexecutor (= 0.72.3)
-    - React-logger
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.3)
-  - React-Fabric/components/scrollview (0.72.3):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.3)
-    - RCTTypeSafety (= 0.72.3)
-    - React-Core
-    - React-debug
-    - React-graphics (= 0.72.3)
-    - React-jsi (= 0.72.3)
-    - React-jsiexecutor (= 0.72.3)
-    - React-logger
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.3)
-  - React-Fabric/components/text (0.72.3):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.3)
-    - RCTTypeSafety (= 0.72.3)
-    - React-Core
-    - React-debug
-    - React-graphics (= 0.72.3)
-    - React-jsi (= 0.72.3)
-    - React-jsiexecutor (= 0.72.3)
-    - React-logger
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.3)
-  - React-Fabric/components/textinput (0.72.3):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.3)
-    - RCTTypeSafety (= 0.72.3)
-    - React-Core
-    - React-debug
-    - React-graphics (= 0.72.3)
-    - React-jsi (= 0.72.3)
-    - React-jsiexecutor (= 0.72.3)
-    - React-logger
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.3)
-  - React-Fabric/components/unimplementedview (0.72.3):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.3)
-    - RCTTypeSafety (= 0.72.3)
-    - React-Core
-    - React-debug
-    - React-graphics (= 0.72.3)
-    - React-jsi (= 0.72.3)
-    - React-jsiexecutor (= 0.72.3)
-    - React-logger
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.3)
-  - React-Fabric/components/view (0.72.3):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.3)
-    - RCTTypeSafety (= 0.72.3)
-    - React-Core
-    - React-debug
-    - React-graphics (= 0.72.3)
-    - React-jsi (= 0.72.3)
-    - React-jsiexecutor (= 0.72.3)
-    - React-logger
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.3)
-    - Yoga
-  - React-Fabric/config (0.72.3):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.3)
-    - RCTTypeSafety (= 0.72.3)
-    - React-Core
-    - React-debug
-    - React-graphics (= 0.72.3)
-    - React-jsi (= 0.72.3)
-    - React-jsiexecutor (= 0.72.3)
-    - React-logger
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.3)
-  - React-Fabric/core (0.72.3):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.3)
-    - RCTTypeSafety (= 0.72.3)
-    - React-Core
-    - React-debug
-    - React-graphics (= 0.72.3)
-    - React-jsi (= 0.72.3)
-    - React-jsiexecutor (= 0.72.3)
-    - React-logger
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.3)
-  - React-Fabric/debug_renderer (0.72.3):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.3)
-    - RCTTypeSafety (= 0.72.3)
-    - React-Core
-    - React-debug
-    - React-graphics (= 0.72.3)
-    - React-jsi (= 0.72.3)
-    - React-jsiexecutor (= 0.72.3)
-    - React-logger
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.3)
-  - React-Fabric/imagemanager (0.72.3):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.3)
-    - RCTTypeSafety (= 0.72.3)
-    - React-Core
-    - React-debug
-    - React-graphics (= 0.72.3)
-    - React-jsi (= 0.72.3)
-    - React-jsiexecutor (= 0.72.3)
-    - React-logger
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.3)
-  - React-Fabric/leakchecker (0.72.3):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.3)
-    - RCTTypeSafety (= 0.72.3)
-    - React-Core
-    - React-debug
-    - React-graphics (= 0.72.3)
-    - React-jsi (= 0.72.3)
-    - React-jsiexecutor (= 0.72.3)
-    - React-logger
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.3)
-  - React-Fabric/mapbuffer (0.72.3):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.3)
-    - RCTTypeSafety (= 0.72.3)
-    - React-Core
-    - React-debug
-    - React-graphics (= 0.72.3)
-    - React-jsi (= 0.72.3)
-    - React-jsiexecutor (= 0.72.3)
-    - React-logger
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.3)
-  - React-Fabric/mounting (0.72.3):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.3)
-    - RCTTypeSafety (= 0.72.3)
-    - React-Core
-    - React-debug
-    - React-graphics (= 0.72.3)
-    - React-jsi (= 0.72.3)
-    - React-jsiexecutor (= 0.72.3)
-    - React-logger
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.3)
-  - React-Fabric/scheduler (0.72.3):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.3)
-    - RCTTypeSafety (= 0.72.3)
-    - React-Core
-    - React-debug
-    - React-graphics (= 0.72.3)
-    - React-jsi (= 0.72.3)
-    - React-jsiexecutor (= 0.72.3)
-    - React-logger
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.3)
-  - React-Fabric/telemetry (0.72.3):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.3)
-    - RCTTypeSafety (= 0.72.3)
-    - React-Core
-    - React-debug
-    - React-graphics (= 0.72.3)
-    - React-jsi (= 0.72.3)
-    - React-jsiexecutor (= 0.72.3)
-    - React-logger
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.3)
-  - React-Fabric/templateprocessor (0.72.3):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.3)
-    - RCTTypeSafety (= 0.72.3)
-    - React-Core
-    - React-debug
-    - React-graphics (= 0.72.3)
-    - React-jsi (= 0.72.3)
-    - React-jsiexecutor (= 0.72.3)
-    - React-logger
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.3)
-  - React-Fabric/textlayoutmanager (0.72.3):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.3)
-    - RCTTypeSafety (= 0.72.3)
-    - React-Core
-    - React-debug
-    - React-Fabric/uimanager
-    - React-graphics (= 0.72.3)
-    - React-jsi (= 0.72.3)
-    - React-jsiexecutor (= 0.72.3)
-    - React-logger
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.3)
-  - React-Fabric/uimanager (0.72.3):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.3)
-    - RCTTypeSafety (= 0.72.3)
-    - React-Core
-    - React-debug
-    - React-graphics (= 0.72.3)
-    - React-jsi (= 0.72.3)
-    - React-jsiexecutor (= 0.72.3)
-    - React-logger
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.3)
-  - React-graphics (0.72.3):
-    - glog
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - React-Core/Default (= 0.72.3)
   - React-hermes (0.72.3):
     - DoubleConversion
     - glog
@@ -1056,14 +405,6 @@ PODS:
     - React-jsiexecutor (= 0.72.3)
     - React-jsinspector (= 0.72.3)
     - React-perflogger (= 0.72.3)
-  - React-ImageManager (0.72.3):
-    - glog
-    - RCT-Folly/Fabric
-    - React-Core/Default
-    - React-debug
-    - React-Fabric
-    - React-RCTImage
-    - React-utils
   - React-jsi (0.72.3):
     - boost (= 1.76.0)
     - DoubleConversion
@@ -1088,35 +429,12 @@ PODS:
   - react-native-netinfo (9.4.1):
     - React-Core
   - react-native-pager-view (6.2.0):
-    - RCT-Folly
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Codegen
     - React-Core
-    - React-RCTFabric
-    - ReactCommon/turbomodule/core
   - react-native-safe-area-context (4.6.3):
     - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - react-native-safe-area-context/common (= 4.6.3)
-    - react-native-safe-area-context/fabric (= 4.6.3)
-    - ReactCommon/turbomodule/core
-  - react-native-safe-area-context/common (4.6.3):
-    - RCT-Folly
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - ReactCommon/turbomodule/core
-  - react-native-safe-area-context/fabric (4.6.3):
-    - RCT-Folly
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Codegen
-    - React-Core
-    - react-native-safe-area-context/common
-    - React-RCTFabric
     - ReactCommon/turbomodule/core
   - React-NativeModulesApple (0.72.3):
     - hermes-engine
@@ -1143,15 +461,11 @@ PODS:
     - RCTTypeSafety
     - React-Core
     - React-CoreModules
-    - React-debug
-    - React-graphics
     - React-hermes
     - React-NativeModulesApple
-    - React-RCTFabric
     - React-RCTImage
     - React-RCTNetwork
     - React-runtimescheduler
-    - React-utils
     - ReactCommon/turbomodule/core
   - React-RCTBlob (0.72.3):
     - hermes-engine
@@ -1162,18 +476,6 @@ PODS:
     - React-jsi (= 0.72.3)
     - React-RCTNetwork (= 0.72.3)
     - ReactCommon/turbomodule/core (= 0.72.3)
-  - React-RCTFabric (0.72.3):
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2021.07.22.00)
-    - React-Core (= 0.72.3)
-    - React-Fabric (= 0.72.3)
-    - React-ImageManager
-    - React-RCTImage (= 0.72.3)
-    - React-RCTText
-    - React-runtimescheduler
-    - React-utils
-    - Yoga
   - React-RCTImage (0.72.3):
     - RCT-Folly (= 2021.07.22.00)
     - RCTTypeSafety (= 0.72.3)
@@ -1247,13 +549,7 @@ PODS:
   - RNCAsyncStorage (1.18.2):
     - React-Core
   - RNGestureHandler (2.12.1):
-    - RCT-Folly
-    - RCTRequired
-    - RCTTypeSafety
-    - React
-    - React-Codegen
-    - React-RCTFabric
-    - ReactCommon/turbomodule/core
+    - React-Core
   - RNReanimated (3.4.2):
     - DoubleConversion
     - FBLazyVector
@@ -1263,7 +559,6 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-callinvoker
-    - React-Codegen
     - React-Core
     - React-Core/DevSupport
     - React-Core/RCTWebSocket
@@ -1275,8 +570,8 @@ PODS:
     - React-jsinspector
     - React-RCTActionSheet
     - React-RCTAnimation
+    - React-RCTAppDelegate
     - React-RCTBlob
-    - React-RCTFabric
     - React-RCTImage
     - React-RCTLinking
     - React-RCTNetwork
@@ -1285,55 +580,10 @@ PODS:
     - ReactCommon/turbomodule/core
     - Yoga
   - RNScreens (3.22.1):
-    - RCT-Folly
-    - RCTRequired
-    - RCTTypeSafety
-    - React
-    - React-Codegen
-    - React-RCTFabric
-    - ReactCommon/turbomodule/core
-    - RNScreens/common (= 3.22.1)
-  - RNScreens/common (3.22.1):
-    - RCT-Folly
-    - RCTRequired
-    - RCTTypeSafety
-    - React
-    - React-Codegen
-    - React-RCTFabric
-    - ReactCommon/turbomodule/core
+    - React-Core
+    - React-RCTImage
   - RNSVG (13.12.0):
-    - hermes-engine
-    - RCT-Folly (= 2021.07.22.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Codegen
     - React-Core
-    - React-debug
-    - React-Fabric
-    - React-graphics
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-utils
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - RNSVG/common (= 13.12.0)
-    - Yoga
-  - RNSVG/common (13.12.0):
-    - hermes-engine
-    - RCT-Folly (= 2021.07.22.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Codegen
-    - React-Core
-    - React-debug
-    - React-Fabric
-    - React-graphics
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-utils
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - Yoga
   - SocketRocket (0.6.1)
   - Yoga (1.14.0)
   - ZXingObjC/Core (3.6.5)
@@ -1371,12 +621,12 @@ DEPENDENCIES:
   - ExpoWebBrowser (from `../node_modules/expo-web-browser/ios`)
   - EXUpdatesInterface (from `../node_modules/expo-updates-interface/ios`)
   - FBLazyVector (from `../node_modules/react-native/Libraries/FBLazyVector`)
+  - FBReactNativeSpec (from `../node_modules/react-native/React/FBReactNativeSpec`)
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
   - hermes-engine (from `../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec`)
   - libevent (~> 2.1.12)
   - lottie-react-native (from `../node_modules/lottie-react-native`)
   - RCT-Folly (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
-  - RCT-Folly/Fabric (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
   - RCTRequired (from `../node_modules/react-native/Libraries/RCTRequired`)
   - RCTTypeSafety (from `../node_modules/react-native/Libraries/TypeSafety`)
   - React (from `../node_modules/react-native/`)
@@ -1387,10 +637,7 @@ DEPENDENCIES:
   - React-CoreModules (from `../node_modules/react-native/React/CoreModules`)
   - React-cxxreact (from `../node_modules/react-native/ReactCommon/cxxreact`)
   - React-debug (from `../node_modules/react-native/ReactCommon/react/debug`)
-  - React-Fabric (from `../node_modules/react-native/ReactCommon`)
-  - React-graphics (from `../node_modules/react-native/ReactCommon/react/renderer/graphics`)
   - React-hermes (from `../node_modules/react-native/ReactCommon/hermes`)
-  - React-ImageManager (from `../node_modules/react-native/ReactCommon/react/renderer/imagemanager/platform/ios`)
   - React-jsi (from `../node_modules/react-native/ReactCommon/jsi`)
   - React-jsiexecutor (from `../node_modules/react-native/ReactCommon/jsiexecutor`)
   - React-jsinspector (from `../node_modules/react-native/ReactCommon/jsinspector`)
@@ -1406,7 +653,6 @@ DEPENDENCIES:
   - React-RCTAnimation (from `../node_modules/react-native/Libraries/NativeAnimation`)
   - React-RCTAppDelegate (from `../node_modules/react-native/Libraries/AppDelegate`)
   - React-RCTBlob (from `../node_modules/react-native/Libraries/Blob`)
-  - React-RCTFabric (from `../node_modules/react-native/React`)
   - React-RCTImage (from `../node_modules/react-native/Libraries/Image`)
   - React-RCTLinking (from `../node_modules/react-native/Libraries/LinkingIOS`)
   - React-RCTNetwork (from `../node_modules/react-native/Libraries/Network`)
@@ -1490,6 +736,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/expo-updates-interface/ios"
   FBLazyVector:
     :path: "../node_modules/react-native/Libraries/FBLazyVector"
+  FBReactNativeSpec:
+    :path: "../node_modules/react-native/React/FBReactNativeSpec"
   glog:
     :podspec: "../node_modules/react-native/third-party-podspecs/glog.podspec"
   hermes-engine:
@@ -1517,14 +765,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/cxxreact"
   React-debug:
     :path: "../node_modules/react-native/ReactCommon/react/debug"
-  React-Fabric:
-    :path: "../node_modules/react-native/ReactCommon"
-  React-graphics:
-    :path: "../node_modules/react-native/ReactCommon/react/renderer/graphics"
   React-hermes:
     :path: "../node_modules/react-native/ReactCommon/hermes"
-  React-ImageManager:
-    :path: "../node_modules/react-native/ReactCommon/react/renderer/imagemanager/platform/ios"
   React-jsi:
     :path: "../node_modules/react-native/ReactCommon/jsi"
   React-jsiexecutor:
@@ -1555,8 +797,6 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/Libraries/AppDelegate"
   React-RCTBlob:
     :path: "../node_modules/react-native/Libraries/Blob"
-  React-RCTFabric:
-    :path: "../node_modules/react-native/React"
   React-RCTImage:
     :path: "../node_modules/react-native/Libraries/Image"
   React-RCTLinking:
@@ -1606,8 +846,8 @@ SPEC CHECKSUMS:
   EXManifests: a9e5206b6b1a6016eea8ddd5c379cf97f7ec89f0
   Expo: d310f3b84bd30843324d41f23ea7cc5e4273abf1
   expo-dev-client: b45e1b2dee3ee0fdeabe0170d32828b70e27860a
-  expo-dev-launcher: 71478400d7a8869757a917823c3f3d8d1ea36ce6
-  expo-dev-menu: e5d538f8d614a26c02cb552907c59e5be0b06d47
+  expo-dev-launcher: 769ab10f74c743f785d7a65f2f0c268fc1e4bbba
+  expo-dev-menu: 9b1704f9e7a2617c344e243e45736f99b0f1bd32
   expo-dev-menu-interface: bda969497e73dadc2663c479e0fa726ca79a306e
   ExpoBlur: a2c90bdfa4ff9f459cdb0f83191bddf020e3e2db
   ExpoClipboard: 695f274f8e028cd113837f917da40c76850877eb
@@ -1616,11 +856,12 @@ SPEC CHECKSUMS:
   ExpoLinearGradient: 5966dd5d49872cc9c104fedc8bbc298b6049b2e8
   ExpoLocalAuthentication: bd9d9037a96a11ccc456e327ddb404df02da10ca
   ExpoLocalization: be37fdd0b5930c6a49cd307b4542f4b426d6134c
-  ExpoModulesCore: 4257da295584d51dc2690458bc3a9b718fc06aac
+  ExpoModulesCore: e4e437139259c5a73530a8895af69774ff8ec12d
   ExpoSecureStore: 57db3b6da8b59046e2057e95bf7738a8027b47c3
   ExpoWebBrowser: 2c788f9c07718a780fe6d8bf2f6195c47609faaa
   EXUpdatesInterface: 91b87edc70c7f597d160c63dbd5d0ae4368f4c2a
   FBLazyVector: 4cce221dd782d3ff7c4172167bba09d58af67ccb
+  FBReactNativeSpec: c6bd9e179757b3c0ecf815864fae8032377903ef
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
   hermes-engine: 10fbd3f62405c41ea07e71973ea61e1878d07322
@@ -1632,15 +873,12 @@ SPEC CHECKSUMS:
   RCTTypeSafety: cb09f3e4747b6d18331a15eb05271de7441ca0b3
   React: 13109005b5353095c052f26af37413340ccf7a5d
   React-callinvoker: c8c87bce983aa499c13cb06d4447c025a35274d6
-  React-Codegen: 6788cb46e79ae61dc63c044aaf2d39e6c2399a71
+  React-Codegen: 712d523524d89d71f1cf7cc624854941be983c4d
   React-Core: 688f88b7f3a3d30b4848036223f8b07102c687e5
   React-CoreModules: 63c063a3ade8fb3b1bec5fd9a50f17b0421558c6
   React-cxxreact: 37765b4975541105b2a3322a4b473417c158c869
   React-debug: 51f11ef8db14b47f24e71c42a4916d4192972156
-  React-Fabric: 5de8ff4cbecbd128bc592e444f3723305598818d
-  React-graphics: a7e3182e68a6e4d79a547a6fcc4e9dc25bf7c22e
   React-hermes: 935ae71fb3d7654e947beba8498835cd5e479707
-  React-ImageManager: 305ec53d6d8c592bab1ef7d068cf18bfbca9f895
   React-jsi: ec628dc7a15ffea969f237b0ea6d2fde212b19dd
   React-jsiexecutor: 59d1eb03af7d30b7d66589c410f13151271e8006
   React-jsinspector: b511447170f561157547bc0bef3f169663860be7
@@ -1648,35 +886,34 @@ SPEC CHECKSUMS:
   react-native-aes: c75c46aa744bef7c2415fdf7f5b2dcb75ca4364d
   react-native-get-random-values: dee677497c6a740b71e5612e8dbd83e7539ed5bb
   react-native-netinfo: fefd4e98d75cbdd6e85fc530f7111a8afdf2b0c5
-  react-native-pager-view: 03aa0e1580050c4a47ff8ac07f43d094057be562
-  react-native-safe-area-context: 405fb2c993ba6b670652292112e14bbf7e261818
+  react-native-pager-view: 0ccb8bf60e2ebd38b1f3669fa3650ecce81db2df
+  react-native-safe-area-context: 36cc67648134e89465663b8172336a19eeda493d
   React-NativeModulesApple: c57f3efe0df288a6532b726ad2d0322a9bf38472
   React-perflogger: 6bd153e776e6beed54c56b0847e1220a3ff92ba5
   React-RCTActionSheet: c0b62af44e610e69d9a2049a682f5dba4e9dff17
   React-RCTAnimation: f9bf9719258926aea9ecb8a2aa2595d3ff9a6022
-  React-RCTAppDelegate: 5ce33de5eb13eec8e8ac9449d4c19380cf3dc241
+  React-RCTAppDelegate: e5ac35d4dbd1fae7df3a62b47db04b6a8d151592
   React-RCTBlob: c4f1e69a6ef739aa42586b876d637dab4e3b5bed
-  React-RCTFabric: 125e7d77057cb62f94e79ac977fd68be042a3bc5
   React-RCTImage: e5798f01aba248416c02a506cf5e6dfcba827638
   React-RCTLinking: f5b6227c879e33206f34e68924c458f57bbb96d9
   React-RCTNetwork: d5554fbfac1c618da3c8fa29933108ea22837788
   React-RCTSettings: 189c71e3e6146ba59f4f7e2cbeb494cf2ad42afa
   React-RCTText: 19425aea9d8b6ccae55a27916355b17ab577e56e
   React-RCTVibration: 388ac0e1455420895d1ca2548401eed964b038a6
-  React-rncore: 77147e3fd9800808d800bba4d67be6e13926c397
+  React-rncore: 755a331dd67b74662108f2d66a384454bf8dc1a1
   React-runtimeexecutor: 369ae9bb3f83b65201c0c8f7d50b72280b5a1dbc
   React-runtimescheduler: 837c1bebd2f84572db17698cd702ceaf585b0d9a
   React-utils: bcb57da67eec2711f8b353f6e3d33bd8e4b2efa3
   ReactCommon: 3ccb8fb14e6b3277e38c73b0ff5e4a1b8db017a9
   RNCAsyncStorage: ddc4ee162bfd41b0d2c68bf2d95acd81dd7f1f93
-  RNGestureHandler: 0f92ab218707c97810df75609886828ee1b7c5e3
-  RNReanimated: 5008fe999d57038a1c5c1163044854d453f41b98
-  RNScreens: cfd9491b1c7cac6a46bfb8c0326a5e79ca3e6286
-  RNSVG: 8214a35877568ca4a0cc15e9c0b92844fce2f0de
+  RNGestureHandler: c0d04458598fcb26052494ae23dda8f8f5162b13
+  RNReanimated: 726395a2fa2f04cea340274ba57a4e659bc0d9c1
+  RNScreens: 50ffe2fa2342eabb2d0afbe19f7c1af286bc7fb3
+  RNSVG: 6d07f8f8f246c85e3e16e0bcfc0d047db0c48496
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   Yoga: 8796b55dba14d7004f980b54bcc9833ee45b28ce
   ZXingObjC: fdbb269f25dd2032da343e06f10224d62f537bdb
 
 PODFILE CHECKSUM: b137bd23e123f24bd06a3ee7600dacfee1dba3ee
 
-COCOAPODS: 1.11.3
+COCOAPODS: 1.12.1

--- a/ios/Podfile.properties.json
+++ b/ios/Podfile.properties.json
@@ -1,6 +1,5 @@
 {
   "expo.jsEngine": "hermes",
   "EX_DEV_CLIENT_NETWORK_INSPECTOR": "true",
-  "ios.deploymentTarget": "13.0",
-  "newArchEnabled": "true"
+  "ios.deploymentTarget": "13.0"
 }


### PR DESCRIPTION
@mvaivre this supersedes your other PR, we can close it (https://github.com/alephium/mobile-wallet/pull/236)

I can successfully run `npm run ios` to run an iOS simulator and `npm run android` for an Android one. No need to run `expo prebuild`, only `pod install`.